### PR TITLE
Revert to current database

### DIFF
--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -54,7 +54,7 @@ if 0:
 if 1:
     import pandokia.db_mysqldb as d
     core_db = d.PandokiaDB( {
-            'host'      : 'plssphdb2',
+            'host'      : 'plssphdbv1',
             'port'      : 3306,
             'user'      : 'etcadmin',
             'passwd'    : password, # stored in /internal/data1/other/config/pswd


### PR DESCRIPTION
Go back to the production database. This will allow us to switch over ssph databases on our own time (plssph3 -> ssph2.etc.stsci.edu) and leave switching over databases as a separate question.

The original plan was to move plssph4 to ssph2.etc.stsci.edu, but as it's not proven working and time is limited, we should go with what works.