### PR TITLE
Fix the SSPH timeout

### DIFF
--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -193,14 +193,16 @@ def run() :
     ###
     # if it took the SP more than 5 minutes to check up on this user, I
     # think something funky is going on.
-    timeobj = datetime.timedelta(datetime.datetime.now(pytz.utc).second - iso8601.parse_date(tyme).second)
+    # datetime.datetime - datetime.datetime = datetime.timedelta (which is what
+    # we actually want.)
+    timeobj = datetime.datetime.now(pytz.utc) - iso8601.parse_date(tyme)
     if timeobj.total_seconds() > 300:
         core_db.execute(
             "UPDATE ssph_auth_events SET consumed = 'E' WHERE auth_event_id = :1 AND sp = :2",
             ( evid, sp )
             )
         core_db.commit()
-        _barf(data, "expired" )
+        _barf(data, "expired ({} - {} = {})".format(datetime.datetime.now(pytz.utc).isoformat(' '), tyme, timeobj))
         return 1
 
     ###

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -207,7 +207,7 @@ def run() :
             )
         core_db.commit()
         logging.debug("expired: {}".format(timeobj.total_seconds()))
-        _barf(data, "expired {}".format(timeobj.total_seconds()))
+        _barf(data, "expired" )
         return 1
 
     ###

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -10,6 +10,7 @@ For extra bonus security, we could keep an IP list of servers that
 host each SP, but I don't think it is worth the extra work.
 
 """
+import logging
 import cgi
 import hashlib
 import json
@@ -29,6 +30,7 @@ with open(urlfile,'r') as servicefile:
 # bug: refuse auth for evid that was used before
 
 from ssph_server.db import core_db
+logging.basicConfig(filename='ssph.log', level=logging.DEBUG)
 
 debug = True
 
@@ -97,6 +99,8 @@ def run() :
         if ipaddr.IPv4Address(remote_addr) in ipaddr.IPNetwork(str(url)) :
 	    match = True
     if not match:
+        logging.debug('Address: {}'.format(ipaddr.IPv4Address(remote_addr)))
+        logging.debug(ipaddr.IPNetwork(str(url)))
         _barf(data,'ip-mismatch')
         sys.exit(1)
 
@@ -149,6 +153,7 @@ def run() :
         # Notice that the choice of hash algorithms is in the SSPH
         # database, so in principle you will never encounter this
         # case, but mistakes happen.
+        logging.debug("hash: {}".format(hash))
         _barf(data, "hash")
         return 1
 
@@ -169,6 +174,7 @@ def run() :
 
     if signature != m.hexdigest() :
         # the client does not know its own secret
+        logging.debug("hash-match: {}, {}".format(signature, m.hexdigest()))
         _barf(data, "hash-match")
         return 1
 
@@ -200,6 +206,7 @@ def run() :
             ( evid, sp )
             )
         core_db.commit()
+        logging.debug("expired: {}".format(timeobj.total_seconds()))
         _barf(data, "expired {}".format(timeobj.total_seconds()))
         return 1
 

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -194,8 +194,8 @@ def run() :
     # if it took the SP more than 5 minutes to check up on this user, I
     # think something funky is going on.
     timeobj = datetime.timedelta(datetime.datetime.now(pytz.utc).second - iso8601.parse_date(tyme).second)
-    sys.stderr.write("Time_in: {}".format(iso8601.parse_date(tyme).second))
-    sys.stderr.write("Time_out: {}".format(datetime.timedelta(datetime.datetime.now(pytz.utc).second)))
+    sys.stderr.write(iso8601.parse_date(tyme).second)
+    sys.stderr.write(datetime.timedelta(datetime.datetime.now(pytz.utc).second))
     sys.stderr.write(timeobj.total_seconds())
     sys.stderr.flush()
     if timeobj.total_seconds() > 300:

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -194,6 +194,10 @@ def run() :
     # if it took the SP more than 5 minutes to check up on this user, I
     # think something funky is going on.
     timeobj = datetime.timedelta(datetime.datetime.now(pytz.utc).second - iso8601.parse_date(tyme).second)
+    sys.stderr.write("Time_in: {}".format(iso8601.parse_date(tyme).second))
+    sys.stderr.write("Time_out: {}".format(datetime.timedelta(datetime.datetime.now(pytz.utc).second)))
+    sys.stderr.write(timeobj.total_seconds())
+    sys.stderr.flush()
     if timeobj.total_seconds() > 300:
         core_db.execute(
             "UPDATE ssph_auth_events SET consumed = 'E' WHERE auth_event_id = :1 AND sp = :2",

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -10,7 +10,6 @@ For extra bonus security, we could keep an IP list of servers that
 host each SP, but I don't think it is worth the extra work.
 
 """
-import logging
 import cgi
 import hashlib
 import json
@@ -30,7 +29,6 @@ with open(urlfile,'r') as servicefile:
 # bug: refuse auth for evid that was used before
 
 from ssph_server.db import core_db
-logging.basicConfig(filename='ssph.log', level=logging.DEBUG)
 
 debug = True
 
@@ -99,8 +97,6 @@ def run() :
         if ipaddr.IPv4Address(remote_addr) in ipaddr.IPNetwork(str(url)) :
 	    match = True
     if not match:
-        logging.debug('Address: {}'.format(ipaddr.IPv4Address(remote_addr)))
-        logging.debug(ipaddr.IPNetwork(str(url)))
         _barf(data,'ip-mismatch')
         sys.exit(1)
 
@@ -153,7 +149,6 @@ def run() :
         # Notice that the choice of hash algorithms is in the SSPH
         # database, so in principle you will never encounter this
         # case, but mistakes happen.
-        logging.debug("hash: {}".format(hash))
         _barf(data, "hash")
         return 1
 
@@ -174,7 +169,6 @@ def run() :
 
     if signature != m.hexdigest() :
         # the client does not know its own secret
-        logging.debug("hash-match: {}, {}".format(signature, m.hexdigest()))
         _barf(data, "hash-match")
         return 1
 
@@ -206,7 +200,6 @@ def run() :
             ( evid, sp )
             )
         core_db.commit()
-        logging.debug("expired: {}".format(timeobj.total_seconds()))
         _barf(data, "expired" )
         return 1
 

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -194,17 +194,13 @@ def run() :
     # if it took the SP more than 5 minutes to check up on this user, I
     # think something funky is going on.
     timeobj = datetime.timedelta(datetime.datetime.now(pytz.utc).second - iso8601.parse_date(tyme).second)
-    sys.stderr.write(iso8601.parse_date(tyme).second)
-    sys.stderr.write(datetime.timedelta(datetime.datetime.now(pytz.utc).second))
-    sys.stderr.write(timeobj.total_seconds())
-    sys.stderr.flush()
     if timeobj.total_seconds() > 300:
         core_db.execute(
             "UPDATE ssph_auth_events SET consumed = 'E' WHERE auth_event_id = :1 AND sp = :2",
             ( evid, sp )
             )
         core_db.commit()
-        _barf(data, "expired")
+        _barf(data, "expired {}".format(timeobj.total_seconds()))
         return 1
 
     ###

--- a/ssph_server/ssph_auth.py
+++ b/ssph_server/ssph_auth.py
@@ -192,6 +192,8 @@ def run() :
     # about time zones.
     tyme = datetime.datetime.utcnow().isoformat(' ')
 
+    sys.stderr.write(tyme)
+    sys.stderr.flush()
 
     if dbtype == "ssph" :
 


### PR DESCRIPTION
In a nutshell, the existing code wasn't converting the date and time to seconds to do the conversion, it was taking the seconds component of the time. And then the datetime.timedelta() was parsing that integer as DAYS. Which means, if ssph authentication lasted, say, from 14.958s to 15.024s, it would conclude the authentication had taken 15-14=1 DAY.

This fixes that. It also provides better logging. The error message will now be something like:
`ERROR IN SSPH? date: 2019-04-16 12:41:32.168814 from: 52.21.154.45 to: 10.128.22.41 type: expired (2019-04-16 16:41:32.168765+00:00 - 2019-04-16 16:41:32.020072 = 50 days, 0:00:00)`

For what it's worth, typical SSPH authorization takes ~0.16s.

Fixes #6