### PR TITLE
JETC-994: CGI scripts should now use TP10

### DIFF
--- a/cgi/secure/sso.cgi
+++ b/cgi/secure/sso.cgi
@@ -1,4 +1,4 @@
-#!/internal/data1/other/tp_9.4/envs/pandeia_9.4/bin/python
+#!/internal/data1/other/tp_10/envs/pandeia_10/bin/python
 from os import environ
 from re import match, compile
 

--- a/cgi/secure/ssph_admin.cgi
+++ b/cgi/secure/ssph_admin.cgi
@@ -1,4 +1,4 @@
-#!/internal/data1/other/tp_9.4/envs/pandeia_9.4/bin/python
+#!/internal/data1/other/tp_10/envs/pandeia_10/bin/python
 # This hook is modified and used for each cgi that gets installed
 import sys
 sys.path.append("/internal/data1/other/pylibs/ssph")

--- a/cgi/secure/ssph_auth.cgi
+++ b/cgi/secure/ssph_auth.cgi
@@ -1,4 +1,4 @@
-#!/internal/data1/other/tp_9.4/envs/pandeia_9.4/bin/python
+#!/internal/data1/other/tp_10/envs/pandeia_10/bin/python
 # This hook is modified and used for each cgi that gets installed
 import sys
 sys.path.append("/internal/data1/other/pylibs/ssph")

--- a/cgi/unsecured/ssph_confirm.cgi
+++ b/cgi/unsecured/ssph_confirm.cgi
@@ -1,4 +1,4 @@
-#!/internal/data1/other/tp_9.4/envs/pandeia_9.4/bin/python
+#!/internal/data1/other/tp_10/envs/pandeia_10/bin/python
 # This hook is modified and used for each cgi that gets installed
 import sys
 sys.path.append("/internal/data1/other/pylibs/ssph")


### PR DESCRIPTION
This is now active on plssph4, which is serving test_3.