### PR TITLE
Try to add encryption for secrets

### DIFF
--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -20,7 +20,21 @@ import os.path
 password_file = '/internal/data1/other/config/pswd'
 
 try:
-    password = open(password_file, "r").readline().strip()
+    with open(fn) as f:
+        encpwd = f.readline().strip()
+        encpwdbyt = bytes(encpwd, 'utf-8')
+    f.close()
+
+    # read key and convert into byte
+    with open(kn) as f:
+        refKey = ''.join(f.readlines())
+        refKeybyt = bytes(refKey, 'utf-8')
+    f.close()
+
+    # use the key and encrypt pwd
+    keytouse = Fernet(refKeybyt)
+    pwbyt = (keytouse.decrypt(encpwdbyt))
+    password = pwbyt.decode("utf-8")
 except IOError:
     password = None
 

--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -73,7 +73,7 @@ if True:
             'host'      : 'plssphdb2',
             'port'      : 3306,
             'user'      : 'etcadmin',
-            'passwd'    : password, # stored in /internal/data1/other/config/pswd
+            'passwd'    : password, # stored in /internal/data1/other/config/encrypted_pswd
             'db'        : 'ssph',
             'use_unicode' : True,
             }

--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -18,16 +18,17 @@ from cryptography.fernet import Fernet
 # The database password is stored in a separate file that belongs
 # to the apache user.  Here is the name of the file.
 
-password_file = '/internal/data1/other/config/pswd'
+password_file = '/internal/data1/other/config/encrypted_pswd'
+key_file = '/internal/data1/other/config/ref_key'
 
 try:
-    with open(fn) as f:
+    with open(password_file) as f:
         encpwd = f.readline().strip()
         encpwdbyt = bytes(encpwd, 'utf-8')
     f.close()
 
     # read key and convert into byte
-    with open(kn) as f:
+    with open(key_file) as f:
         refKey = ''.join(f.readlines())
         refKeybyt = bytes(refKey, 'utf-8')
     f.close()

--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -36,7 +36,7 @@ try:
     # use the key and encrypt pwd
     keytouse = Fernet(refKeybyt)
     pwbyt = (keytouse.decrypt(encpwdbyt))
-    password = pwbyt.decode("utf-8")
+    password = pwbyt.decode("utf-8").strip()
 except IOError:
     password = None
 

--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -10,6 +10,7 @@
 #
 
 import os.path
+from cryptography.fernet import Fernet
 
 #####
 # database password - common to all


### PR DESCRIPTION
Encrypted secrets and key already generated and put into the respective directory.

Manual testing: using same code segment to decrypt and print out the password plainly, example:
```
(pandeia_16.1) -bash-4.2$ python test2.py
my password -  1234567890+_~lalala

(pandeia_16.1) -bash-4.2$ cd -
/internal/data1/secrets
(pandeia_16.1) -bash-4.2$ cat test
1234567890+_~lalala
(pandeia_16.1) -bash-4.2$ cat encrypted_test
gAAAAABmIULCnl96-v02L9E_3Ra21Xfv9ykrSaKZS0NhAhINYXedgfcoqHK4HxuURUc9XRREfmScfn3cbzrIPn5uYiUTRO_B__MYEx31aMlu85ONcDcHcVk=
-bash-4.2$ cat test2.py
from cryptography.fernet import Fernet

# read encrypted pwd and convert into byte
with open('/internal/data1/secrets/encrypted_test') as f:
    encpwd = f.read().strip()
    encpwdbyt = bytes(encpwd, 'utf-8')
f.close()

# read key and convert into byte
with open('/internal/data1/secrets/ref_key') as f:
    refKey = ''.join(f.readlines())
    refKeybyt = bytes(refKey, 'utf-8')
f.close()

# use the key and encrypt pwd
keytouse = Fernet(refKeybyt)
myPassbyt = (keytouse.decrypt(encpwdbyt))
myPass = myPassbyt.decode("utf-8")
print("my password - ",myPass)
```

Test run: https://glitch.etc.stsci.edu/jwst/test/reports/user_pandeia_jwst_oit_secret_JETC-513_2024-04-22-12:21:01.html

PR that has the same change: https://github.com/spacetelescope/etc-controller/pull/135

Address [JETC-513](https://jira.stsci.edu/browse/JETC-513)