### PR TITLE
JETC-4397: Update the SSPH database to the new RHEL9 one.

### DIFF
--- a/ssph_server/db.py
+++ b/ssph_server/db.py
@@ -70,7 +70,7 @@ if False:
 if True:
     import pandokia.db_mysqldb as d
     core_db = d.PandokiaDB( {
-            'host'      : 'plssphdb2',
+            'host'      : 'pljwstdbs',
             'port'      : 3306,
             'user'      : 'etcadmin',
             'passwd'    : password, # stored in /internal/data1/other/config/encrypted_pswd


### PR DESCRIPTION
We now have a working database on pljwstdbs that SSPH4 can use (and SSPH3, the next time we have production downtime, or if we're OK with everything glitching for a second while we switch databases)