### PR TITLE
[WIP] JETC-3502: Replace cgi by rewriting SSPH to use Flask

### DIFF
--- a/cgi/ssph.cgi
+++ b/cgi/ssph.cgi
@@ -1,0 +1,58 @@
+#!/internal/data1/other/third_party/envs/pandeia_17/bin/python
+import sys
+sys.path.append("/internal/data1/other/pylibs/ssph")
+
+import sys
+from os import environ
+from re import match, compile
+import ssph_server.admin as admin
+import ssph_server.ssph_auth as auth
+import ssph_server.confirm as confirm
+
+from flask import Flask, request, redirect
+
+app = Flask(__name__)
+
+
+def process_data():
+    if request.method == "GET":
+        data = request.args
+    elif request.method == "POST":
+        data = request.form
+
+@app.route("/secure/ssph_admin.cgi", methods=["GET", "POST"])
+def admin_page():
+    data = process_data()
+    
+    return admin.run(data)
+
+@app.route("/secure/ssph_auth.cgi", methods=["GET", "POST"])
+def auth_page():
+    data = process_data()
+    
+    return auth.run(data)
+
+@app.route("/unsecured/ssph_confirm.cgi", methods=["GET", "POST"])
+def confirm_page():
+    data = process_data()
+    
+    return confirm.run(data)
+
+@app.route("/secure/sso.cgi")
+def sso_page():
+    shib_vars = compile('(STScI_|Shib_|[a-z_0-9])+')
+
+    msg = 'Content-Type: text/html\n'
+
+    msg += '<!DOCTYPE html><html><body>\n'
+
+    for i in sorted(environ):
+        if shib_vars.match(i):
+            msg += '<span style="color:red">'
+        else:
+            msg += '<span>'
+    msg += f'<strong>{i}</strong>={environ[i]}</span><br>\n'
+
+    msg += '</body>\n</html>'
+
+    return msg

--- a/cgi/ssph.py
+++ b/cgi/ssph.py
@@ -19,6 +19,7 @@ def process_data():
         data = request.args
     elif request.method == "POST":
         data = request.form
+    return data
 
 @app.route("/secure/ssph_admin.cgi", methods=["GET", "POST"])
 def admin_page():

--- a/ssph_server/admin.py
+++ b/ssph_server/admin.py
@@ -37,7 +37,7 @@ from ssph_server.db import core_db
 from ssph_server.admin_text import html_page
 
 def run(data):
-
+    
     # BUG: include the IDP in this test
     if not (os.environ.get("Shib_Identity_Provider"), os.environ.get('STScI_UUID')) in permitted_users:
         msg = "status: 500\ncontent-type: text/plain\n"
@@ -45,7 +45,7 @@ def run(data):
         msg += f"you are {os.environ["Shib_Identity_Provider"]}, {os.environ['STScI_UUID']}" 
         return msg
 
-    if 'listsp' in data:
+    if 'listsp'in data:
         t = listtb('ssph_sp_info', order_by='ORDER BY sp')
         return "content-type: text/html\n\n{}".format(t.get_html(headings=True))
 
@@ -66,12 +66,10 @@ def run(data):
         set_db_pass(data)
     
     elif 'get_db_pass' in data:
-        get_db_pass(data)
+        get_db_pass()
     
     else:
-        # None of the CGI parameters were present, so this is not a form
-        # submission.  Show the user the form.
-        return "content-type: text/html\n\n{}".format(html_page)
+        return show_form()
 
 def listtb(table, order_by=''):
     c = core_db.execute("select * from %s %s" % (table, order_by))
@@ -130,7 +128,7 @@ def form_test(data):
         print(f"{x}: {os.environ[x]}\n")
     sys.exit()
 
-def get_db_pass(data):
+def get_db_pass():
     from ssph_server.db import password_file
     with open(password_file,"r") as pswdfile:
         pswd = pswdfile.read()
@@ -143,3 +141,8 @@ def set_db_pass(data):
     f.write(data['db_pass'])
     f.close()
     return "content-type: text/plain\n\ndone"
+
+def show_form():
+    # None of the CGI parameters were present, so this is not a form
+    # submission.  Show the user the form.
+    return "content-type: text/html\n\n{}".format(html_page)

--- a/ssph_server/admin.py
+++ b/ssph_server/admin.py
@@ -41,7 +41,7 @@ from ssph_server.admin_text import html_page
 
 app = Flask(__name__)
 
-@app.route("/ssph_admin.cgi", methods=["GET", "POST"])
+@app.route("/", methods=["GET", "POST"])
 def run():
     # BUG: include the IDP in this test
     if not (os.environ["Shib_Identity_Provider"], os.environ['STScI_UUID']) in permitted_users:

--- a/ssph_server/admin.py
+++ b/ssph_server/admin.py
@@ -54,19 +54,19 @@ def run(data):
         return "content-type: text/html\n\n{}".format(t.get_html(headings=True))
 
     elif "sp" in data:
-        add_sp(data)
+        return add_sp(data)
 
     elif 'delete_sp' in data:
-        delete_sp(data)
+        return delete_sp(data)
 
     elif 'form_test' in data:
-        form_test(data)
+        return form_test(data)
 
     elif 'db_pass' in data:
-        set_db_pass(data)
+        return set_db_pass(data)
     
     elif 'get_db_pass' in data:
-        get_db_pass()
+        return get_db_pass()
     
     else:
         return show_form()
@@ -120,13 +120,13 @@ def delete_sp(data):
     return "content-type: text/plain\n\ndone"
 
 def form_test(data):
-    print("content-type: text/plain\n\n")
+    msg = "content-type: text/plain\n\n"
     for x in data:
-        print(f"{x}: {data[x]}\n")
-    print("--------------------------------\n")
+        msg += f"{x}: {data[x]}\n"
+    msg += "--------------------------------\n"
     for x in os.environ:
-        print(f"{x}: {os.environ[x]}\n")
-    sys.exit()
+        msg += f"{x}: {os.environ[x]}\n"
+    return msg
 
 def get_db_pass():
     from ssph_server.db import password_file

--- a/ssph_server/admin.py
+++ b/ssph_server/admin.py
@@ -29,8 +29,6 @@ permitted_users = (
 import os
 import sys
 
-from flask import Flask, request, redirect
-
 # unremarkable way to shove the database table into a pandokia
 # text_table and then display it as html.
 import pandokia.text_table
@@ -38,98 +36,42 @@ from ssph_server.db import core_db
 
 from ssph_server.admin_text import html_page
 
+def run(data):
 
-app = Flask(__name__)
-
-@app.route("/", methods=["GET", "POST"])
-def run():
     # BUG: include the IDP in this test
-    if not (os.environ["Shib_Identity_Provider"], os.environ['STScI_UUID']) in permitted_users:
+    if not (os.environ.get("Shib_Identity_Provider"), os.environ.get('STScI_UUID')) in permitted_users:
         msg = "status: 500\ncontent-type: text/plain\n"
         msg += "\nlogged in but not permitted to admin\n"
         msg += f"you are {os.environ["Shib_Identity_Provider"]}, {os.environ['STScI_UUID']}" 
         return msg
 
-    # # get the cgi parameters
-    # data = cgi.FieldStorage()
+    if 'listsp' in data:
+        t = listtb('ssph_sp_info', order_by='ORDER BY sp')
+        return "content-type: text/html\n\n{}".format(t.get_html(headings=True))
 
-    # if 'db_pass' in data:
-    #     from ssph_server.db import password_file
-    #     f=open(password_file,"w")
-    #     os.chmod(password_file, 0o600)
-    #     f.write(data['db_pass'].value)
-    #     f.close()
-    #     print("content-type: text/plain\n\ndone")
-    #     sys.exit()
+    elif 'listau' in data:
+        t = listtb('ssph_auth_events', 'ORDER BY tyme DESC LIMIT 100')
+        return "content-type: text/html\n\n{}".format(t.get_html(headings=True))
 
-    # if 'get_db_pass' in data:
-    #     from ssph_server.db import password_file
-    #     f=open(password_file,"r")
-    #     print("content-type: text/plain\n\n{}".format(f.read()))
-    #     f.close()
-    #     sys.exit()
+    elif "sp" in data:
+        add_sp(data)
 
-    # if "form_test" in data:
-    #     print("content-type: text/plain\n\n")
-    #     for x in data:
-    #         print(f"{x}: {data[x]}\n")
-    #     print("--------------------------------\n")
-    #     for x in os.environ:
-    #         print(f"{x}: {os.environ[x]}\n")
-    #     sys.exit()
+    elif 'delete_sp' in data:
+        delete_sp(data)
 
-    # if 'sp' in data:
-    #     import json
-    #     from ssph_server.db import core_db
+    elif 'form_test' in data:
+        form_test(data)
 
-    #     dbcreds = data['dbcreds'].value
-
-    #     if dbcreds != "":
-    #         dbcreds = json.dumps(json.loads(dbcreds))
-
-    #     core_db.execute("""
-    #         INSERT INTO ssph_sp_info
-    #         ( sp, url, dbtype, dbcreds, contact, email, secret, hash )
-    #         VALUES
-    #         ( :1, :2, :3,      :4,      :5,     :6,      :7,    :8 )
-    #         """,
-    #         (   data['sp'].value,
-    #             data['url'].value,
-    #             data['dbtype'].value,
-    #             dbcreds,
-    #             data['contact'].value,
-    #             data['email'].value,
-    #             data['secret'].value,
-    #             data['hash'].value
-    #         )
-    #     )
-
-    #     core_db.commit()
-    #     print("content-type: text/plain\n\ndone")
-    #     sys.exit()
-
-    # if 'delete_sp' in data:
-    #     from ssph_server.db import core_db
-    #     c = core_db.execute("DELETE FROM ssph_sp_info WHERE sp = :1 ",
-    #         (data['delete_sp'].value,)
-    #         )
-    #     core_db.commit()
-    #     print("content-type: text/plain\n\ndone")
-    #     sys.exit()
-
-    # if 'listsp' in data:
-    #     t = listtb('ssph_sp_info', order_by='ORDER BY sp')
-    #     print("content-type: text/html\n\n{}".format(t.get_html(headings=True)))
-    #     sys.exit()
-
-    # if 'listau' in data:
-    #     t = listtb('ssph_auth_events', 'ORDER BY tyme DESC LIMIT 100')
-    #     print("content-type: text/html\n\n{}".format(t.get_html(headings=True)))
-    #     sys.exit()
-
-    # None of the CGI parameters were present, so this is not a form
-    # submission.  Show the user the form.
-    return "content-type: text/html\n\n{}".format(html_page)
+    elif 'db_pass' in data:
+        set_db_pass(data)
+    
+    elif 'get_db_pass' in data:
+        get_db_pass(data)
+    
+    else:
+        # None of the CGI parameters were present, so this is not a form
+        # submission.  Show the user the form.
+        return "content-type: text/html\n\n{}".format(html_page)
 
 def listtb(table, order_by=''):
     c = core_db.execute("select * from %s %s" % (table, order_by))
@@ -141,3 +83,63 @@ def listtb(table, order_by=''):
         for col, value in enumerate(x):
             t.set_value(row, col, value )
     return t
+
+def add_sp(data):
+    import json
+    from ssph_server.db import core_db
+
+    dbcreds = data['dbcreds']
+
+    if dbcreds != "":
+        dbcreds = json.dumps(json.loads(dbcreds))
+
+    core_db.execute("""
+        INSERT INTO ssph_sp_info
+        ( sp, url, dbtype, dbcreds, contact, email, secret, hash )
+        VALUES
+        ( :1, :2, :3,      :4,      :5,     :6,      :7,    :8 )
+        """,
+        (   data['sp'],
+            data['url'],
+            data['dbtype'],
+            dbcreds,
+            data['contact'],
+            data['email'],
+            data['secret'],
+            data['hash']
+        )
+    )
+
+    core_db.commit()
+    return "content-type: text/plain\n\ndone"
+
+def delete_sp(data):
+    from ssph_server.db import core_db
+    c = core_db.execute("DELETE FROM ssph_sp_info WHERE sp = :1 ",
+        (data['delete_sp'],)
+        )
+    core_db.commit()
+    return "content-type: text/plain\n\ndone"
+
+def form_test(data):
+    print("content-type: text/plain\n\n")
+    for x in data:
+        print(f"{x}: {data[x]}\n")
+    print("--------------------------------\n")
+    for x in os.environ:
+        print(f"{x}: {os.environ[x]}\n")
+    sys.exit()
+
+def get_db_pass(data):
+    from ssph_server.db import password_file
+    with open(password_file,"r") as pswdfile:
+        pswd = pswdfile.read()
+    return f"content-type: text/plain\n\n{pswd}"
+
+def set_db_pass(data):
+    from ssph_server.db import password_file
+    f=open(password_file,"w")
+    os.chmod(password_file, 0o600)
+    f.write(data['db_pass'])
+    f.close()
+    return "content-type: text/plain\n\ndone"

--- a/ssph_server/admin.py
+++ b/ssph_server/admin.py
@@ -72,6 +72,14 @@ def run():
         f.close()
         sys.exit()
 
+    if "form_test" in data:
+        print("content-type: text/plain\n\n")
+        for x in data:
+            print(f"{x}: {data[x]}\n")
+        print("--------------------------------\n")
+        for x in os.environ:
+            print(f"{x}: {os.environ[x]}\n")
+        sys.exit()
 
     if 'sp' in data:
         import json

--- a/ssph_server/admin_text.py
+++ b/ssph_server/admin_text.py
@@ -59,7 +59,7 @@ html_page = """
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
 <hr>
 <form action='/secure/ssph_admin.cgi' method=post>
-<input type=submit name=submit value="Test Form Input>
+<input type=submit name=submit value="Test Form Input">
 <input type=text name=form_test size=80>
 </form>
 

--- a/ssph_server/admin_text.py
+++ b/ssph_server/admin_text.py
@@ -59,6 +59,13 @@ html_page = """
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
 <hr>
 <form action='/secure/ssph_admin.cgi' method=post>
+<input type=submit name=submit value="Test Form Input>
+<input type=text name=form_test size=80>
+</form>
+
+<!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+<hr>
+<form action='/secure/ssph_admin.cgi' method=post>
 <input type=text name=delete_sp>
 <input type=submit name=delete value="Delete SP">
 </form>

--- a/ssph_server/confirm.py
+++ b/ssph_server/confirm.py
@@ -10,7 +10,6 @@ For extra bonus security, we could keep an IP list of servers that
 host each SP, but I don't think it is worth the extra work.
 
 """
-import cgi
 import hashlib
 import json
 import os
@@ -70,21 +69,17 @@ def _barf(data, message):
 #
 #
 
-def run():
+def run(data):
     # checking that the client is in the network range that we expect
     # to serve
     remote_addr = os.getenv("REMOTE_ADDR", '')
     ###
 
-    # Collect the fields of the query that was passed by the client.
-    # Quietly ignore unexpected fields.
-    data = cgi.FieldStorage()
-
-    sp = data["sp"].value
+    sp = data["sp"]
         # the name of the SP that is the client here
-    evid = data["evid"].value
+    evid = data["evid"]
         # the session authentication event id being validated
-    signature = data["sig"].value
+    signature = data["sig"]
         # the hash computed by the client of the input for this request
 
     ### write your own if statements here
@@ -234,5 +229,4 @@ def run():
     # send back 1 line of signature, then arbitrarily long information.
     # (in practice, it is usually a single line of json, but it might
     # be multi-line if somebody pretty printed it into the database.)
-    print("content-type: text/plain\n\n{}\n{}".format(signature, attribs))
-    sys.exit()
+    return "content-type: text/plain\n\n{}\n{}".format(signature, attribs)


### PR DESCRIPTION
The standard wisdom (from both the internet and from the python slack channel) is that the best replacement for the cgi module is to use a framework (Flask, Django, Tornado). 
Flask is not a framework we've used before but it seems to be very light-weight.

I cannot test this in place yet because it requires a lot of server work, but it would replace the current CGI scripts with a Python WSGI application. When running this locally, the flask debugging lets me see that all of the various options fail because the expected files or databases don't exist on my laptop, which is what we want to see and couldn't see with the various POST-reading replacements I have tried thus far.

Instead of a set of disconnected files in the webroot, the entire application is now one single connected application called "ssph". All of the business logic is still in folders outside the webroot, which I believe was the security concern before, only the `ssph.py` file would have to sit in the webroot.

Still to do: 
* flask apparently expects to "return" values instead of "print"ing them, and appears to have a different mechanism for setting content types.
* get Apache set up on plssph6 to serve ssph.py (which may involve proxy settings for Flask) instead of the current webroot files.
* Test it
